### PR TITLE
Expanding information regarding character combos for Western languages

### DIFF
--- a/subtitle-convert.c
+++ b/subtitle-convert.c
@@ -1,6 +1,7 @@
 /*
 	written by Missingno_force a.k.a. Missingmew
 	Copyright (c) 2014-2018
+	Expanded accent information by IlDucci (c) 2023
 	see LICENSE for details
 */
 
@@ -17,27 +18,80 @@ typedef struct {
 	uint32_t textId;
 }__attribute__((packed)) subLineHeader;
 
+// NOTE FOR FUTURE EDITORS: MAKE SURE TO CONVERT THIS CODE SO IT OUTPUTS UTF-8 STRINGS, OTHERWISE YOU WILL HAVE:
+// - ISSUES WHEN DISPLAYING CERTAIN EUC-JP CHARACTERS USED IN THE WESTERN VERSIONS (BUTTON KEYS, 0xA1C8/0xA1C9 QUOTATION MARKS).
+// - COLLISIONS BETWEEN THE OPENING EXCLAMATION MARK (¡, 0xA1) AND THE BEFOREMENTIONED CHARACTERS.
+
 char getModdedLetter( int modifier, int letter ) {
 	if( modifier == 0x60 ) { // `
+		if( letter == 0x41 ) return 0xC0; // A, À
+		if( letter == 0x45 ) return 0xC8; // E, È
+		if( letter == 0x49 ) return 0xCC; // I, Ì
+		if( letter == 0x4F ) return 0xD2; // O, Ò
+		if( letter == 0x55 ) return 0xD9; // U, Ù
 		if( letter == 0x61 ) return 0xE0; // a, à
 		if( letter == 0x65 ) return 0xE8; // e, è
+		if( letter == 0x69 ) return 0xEC; // i, ì
 		if( letter == 0x6F ) return 0xF2; // o, ò
+		if( letter == 0x75 ) return 0xF9; // u, ù
 	}
 	if( modifier == 0x5E ) { // ^
-		if( letter == 0x75 ) return 0xFB; // u, û
+		if( letter == 0x41 ) return 0xC2; // A, Â
+		if( letter == 0x45 ) return 0xCA; // E, Ê
+		if( letter == 0x49 ) return 0xCE; // I, Î
+		if( letter == 0x4F ) return 0xD4; // O, Ô
+		if( letter == 0x55 ) return 0xDB; // U, Û
+		if( letter == 0x61 ) return 0xE2; // a, â
 		if( letter == 0x65 ) return 0xEA; // e, ê
+		if( letter == 0x69 ) return 0xEE; // i, î
+		if( letter == 0x6F ) return 0xF2; // o, ô
+		if( letter == 0x75 ) return 0xFB; // u, û
+	}
+	if( modifier == 0x25 ) { // %
+		if( letter == 0x4F ) return 0xB0; // O, °
+		// THE GAME DOES NOT HAVE A COMBO TO WRITE THE UPPERCASE "Å"
+		if( letter == 0x61 ) return 0xE5; // a, å
+		if( letter == 0x6F ) return 0xBA; // o, º
 	}
 	if( modifier == 0x27 ) { // '
+		if( letter == 0x41 ) return 0xC1; // A, Á
+		if( letter == 0x45 ) return 0xC9; // E, É
+		if( letter == 0x49 ) return 0xCD; // I, Í
+		if( letter == 0x4F ) return 0xD3; // O, Ó
+		if( letter == 0x55 ) return 0xDA; // U, Ú
+		if( letter == 0x59 ) return 0xDD; // Y, Ý
+		if( letter == 0x61 ) return 0xE1; // a, á
 		if( letter == 0x65 ) return 0xE9; // e, é
+		if( letter == 0x69 ) return 0xED; // i, í
+		if( letter == 0x6F ) return 0xF3; // o, ó
+		if( letter == 0x75 ) return 0xFA; // u, ú
+		if( letter == 0x79 ) return 0xFF; // y, ý
 	}
 	if( modifier == 0x7E ) { // ~
-		if( letter == 0x71 ) return 0xE7; // q, ç
+		if( letter == 0x21 ) return 0xA1; // !, ¡
+		if( letter == 0x3C ) return 0xAB; // <, «
+		if( letter == 0x3E ) return 0xBB; // >, »
+		if( letter == 0x3F ) return 0xBF; // ?, ¿
+		if( letter == 0x41 ) return 0xC4; // A, Ä
+		if( letter == 0x45 ) return 0xCB; // E, Ë
+		if( letter == 0x49 ) return 0xCF; // I, Ï
+		// THE GAME DOES NOT HAVE WORKING COMBOS FOR Ã, Õ, ã, õ.
+		if( letter == 0x4E ) return 0xD1; // N, Ñ
+		if( letter == 0x4F ) return 0xD6; // O, Ö
+		if( letter == 0x51 ) return 0xC7; // Q, Ç
+		if( letter == 0x55 ) return 0xDC; // U, Ü
 		if( letter == 0x61 ) return 0xE4; // a, ä
+		if( letter == 0x65 ) return 0xEB; // e, ë
+		if( letter == 0x69 ) return 0xEF; // i, ï
+		if( letter == 0x6E ) return 0xF1; // n, ñ
 		if( letter == 0x6F ) return 0xF6; // o, ö
-		if( letter == 0x75 ) return 0xFC; // u, ü
+		if( letter == 0x71 ) return 0xE7; // q, ç
 		if( letter == 0x73 ) return 0xDF; // s, ß
+		if( letter == 0x75 ) return 0xFC; // u, ü
+		if( letter == 0x79 ) return 0xFF; // y, ÿ
 	}
 	if( modifier == 0x40 ) { // @
+		if( letter == 0x45 ) return 0x8C; // O, Œ
 		if( letter == 0x65 ) return 0x9C; // o, œ
 	}
 	return 0;


### PR DESCRIPTION
This PR expands the Western character table (both PAL and NTSC-U share it) with all the characters I have found while doing a pass at my old Spanish translation.

My tests consisted in editing a number of weapon descriptions to add all the possible combos of a certain key + ASCII characters and see what changed. I have only researched these ranges:
 - Space (0x20) to 3 (0x33)
 - Colon (0x3A) to A (0x41)
 - Left square bracket (0x5B) to a (0x61)
 - Left curly bracket (0x7B) to tilde (0x7E).

I have not tested all the remaining numbers, uppercase characters or lowercase characters, but considering all the already known chars were linked to punctuation signs, I am assuming the untested characters will give no new results.

NOTE FOR FUTURE EDITORS: MAKE SURE TO CONVERT THIS CODE SO IT OUTPUTS UTF-8 STRINGS, OTHERWISE YOU WILL HAVE:
 - ISSUES WHEN DISPLAYING CERTAIN EUC-JP CHARACTERS USED IN THE WESTERN VERSIONS (BUTTON KEYS, 0xA1C8/0xA1C9 QUOTATION MARKS).
 - COLLISIONS BETWEEN THE OPENING EXCLAMATION MARK (¡, 0xA1) AND THE BEFOREMENTIONED CHARACTERS.